### PR TITLE
feat(offhours-guard): deploy operator and schedule arffornia servers

### DIFF
--- a/k8s/apps/kustomization.yaml
+++ b/k8s/apps/kustomization.yaml
@@ -36,6 +36,7 @@ resources:
   - monitoring.yaml
 
   # Applications
+  - offhours-guard.yaml
   - adminer.yaml
   - nextcloud.yaml
   - vaultwarden.yaml

--- a/k8s/apps/offhours-guard.yaml
+++ b/k8s/apps/offhours-guard.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: offhours-guard
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - ServerSideApply=true
+      - CreateNamespace=true
+  project: default
+  source:
+    repoURL: https://github.com/TheGostsniperfr/infra.git
+    targetRevision: HEAD
+    path: k8s/config/offhours-guard
+  destination:
+    name: in-cluster
+    namespace: offhours-guard

--- a/k8s/config/arffornia/proxy/kustomization.yaml
+++ b/k8s/config/arffornia/proxy/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - namespace.yaml
   - secret.yaml
   - config.yaml
+  - offhours-guard.yaml
 
 helmCharts:
   - name: minecraft-proxy

--- a/k8s/config/arffornia/proxy/offhours-guard.yaml
+++ b/k8s/config/arffornia/proxy/offhours-guard.yaml
@@ -1,0 +1,11 @@
+apiVersion: guard.3istor.com/v1alpha1
+kind: OffhoursSchedule
+metadata:
+  name: arffornia-proxy-velocity
+  namespace: arffornia-proxy-velocity
+spec:
+  sleepAt: "0 3 * * *" # 03:00 Europe/Paris
+  wakeAt: "0 7 * * *" # 07:00 Europe/Paris
+  timezone: "Europe/Paris"
+  targetRefs:
+    - name: arffornia-proxy-velocity-minecraft-proxy

--- a/k8s/config/arffornia/server/overlays/arcane/kustomization.yaml
+++ b/k8s/config/arffornia/server/overlays/arcane/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - pvc.yaml
   - servicemonitor.yaml
   - addition-config.yaml
+  - offhours-guard.yaml
 
 helmCharts:
   - name: minecraft

--- a/k8s/config/arffornia/server/overlays/arcane/offhours-guard.yaml
+++ b/k8s/config/arffornia/server/overlays/arcane/offhours-guard.yaml
@@ -1,0 +1,11 @@
+apiVersion: guard.3istor.com/v1alpha1
+kind: OffhoursSchedule
+metadata:
+  name: arffornia-server-arcane
+  namespace: arffornia-server-arcane
+spec:
+  sleepAt: "0 3 * * *" # 03:00 Europe/Paris
+  wakeAt: "0 7 * * *" # 07:00 Europe/Paris
+  timezone: "Europe/Paris"
+  targetRefs:
+    - name: arffornia-server-arcane-minecraft

--- a/k8s/config/arffornia/server/overlays/nexus/kustomization.yaml
+++ b/k8s/config/arffornia/server/overlays/nexus/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - namespace.yaml
   - addition-config.yaml
   - pvc.yaml
+  - offhours-guard.yaml
 
 helmCharts:
   - name: minecraft

--- a/k8s/config/arffornia/server/overlays/nexus/offhours-guard.yaml
+++ b/k8s/config/arffornia/server/overlays/nexus/offhours-guard.yaml
@@ -1,0 +1,11 @@
+apiVersion: guard.3istor.com/v1alpha1
+kind: OffhoursSchedule
+metadata:
+  name: arffornia-server-nexus
+  namespace: arffornia-server-nexus
+spec:
+  sleepAt: "0 3 * * *" # 03:00 Europe/Paris
+  wakeAt: "0 7 * * *" # 07:00 Europe/Paris
+  timezone: "Europe/Paris"
+  targetRefs:
+    - name: arffornia-server-nexus-minecraft

--- a/k8s/config/offhours-guard/kustomization.yaml
+++ b/k8s/config/offhours-guard/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: offhours-guard
+
+resources:
+  - namespace.yaml
+
+helmGlobals:
+  chartHome: ../../../charts
+
+helmCharts:
+  - name: offhours-guard
+    repo: oci://ghcr.io/thegostsniperfr/charts
+    version: 1.1.7
+    releaseName: offhours-guard
+    namespace: offhours-guard
+    valuesFile: offhours-guard-values.yaml
+
+  - name: secure-route
+    releaseName: offhours-guard-routes
+    namespace: offhours-guard
+    valuesFile: values-secure-route.yaml

--- a/k8s/config/offhours-guard/namespace.yaml
+++ b/k8s/config/offhours-guard/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: offhours-guard
+  labels:
+    prod-gateway-access: "true"

--- a/k8s/config/offhours-guard/offhours-guard-values.yaml
+++ b/k8s/config/offhours-guard/offhours-guard-values.yaml
@@ -1,0 +1,4 @@
+image:
+  repository: ghcr.io/thegostsniperfr/offhours-guard
+  tag: "1.1.7"
+  pullPolicy: IfNotPresent

--- a/k8s/config/offhours-guard/values-secure-route.yaml
+++ b/k8s/config/offhours-guard/values-secure-route.yaml
@@ -1,0 +1,15 @@
+routes:
+  offhours-guard:
+    hostnames:
+      - "offhours-guard.arffornia.com"
+    rules:
+      - backendRefs:
+          - name: offhours-guard
+            port: 8082
+    auth:
+      enabled: true
+      vault:
+        path: "kvv2/offhours-guard/envoy-auth"
+        role: "offhours-guard-role"
+    ipFilter:
+      enabled: false

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -24,9 +24,10 @@ locals {
     "nextcloud"   = true
     "vault"       = true
     "vaultwarden" = true
-    "www"         = true
-    "map"         = true
-    "coder"       = true
+    "www"            = true
+    "map"            = true
+    "coder"          = true
+    "offhours-guard" = true
 
     # DNS Only (Grey Cloud)
     "auth"       = false

--- a/terraform/policies.tf
+++ b/terraform/policies.tf
@@ -32,6 +32,17 @@ resource "vault_policy" "arffornia_website_policy" {
 }
 
 # -----------------------------------------------------------------------------
+# Offhours Guard Policy
+# -----------------------------------------------------------------------------
+
+resource "vault_policy" "offhours_guard_policy" {
+  name = "offhours-guard-policy"
+  policy = templatefile("${path.module}/policies/offhours_guard.hcl", {
+    mount_path = vault_mount.kvv2.path
+  })
+}
+
+# -----------------------------------------------------------------------------
 # Adminer Policy
 # -----------------------------------------------------------------------------
 

--- a/terraform/policies/offhours_guard.hcl
+++ b/terraform/policies/offhours_guard.hcl
@@ -1,0 +1,4 @@
+# Offhours Guard Policy
+path "${mount_path}/data/offhours-guard/envoy-auth" {
+  capabilities = ["read"]
+}

--- a/terraform/roles.tf
+++ b/terraform/roles.tf
@@ -40,6 +40,19 @@ resource "vault_kubernetes_auth_backend_role" "arffornia_website_role" {
 }
 
 # -----------------------------------------------------------------------------
+# Offhours Guard Role
+# -----------------------------------------------------------------------------
+
+resource "vault_kubernetes_auth_backend_role" "offhours_guard_role" {
+  backend                          = vault_auth_backend.kubernetes.path
+  role_name                        = "offhours-guard-role"
+  bound_service_account_names      = ["vault-secrets-operator"]
+  bound_service_account_namespaces = ["vault-secrets-operator"]
+  token_ttl                        = 86400 # 24h
+  token_policies                   = [vault_policy.offhours_guard_policy.name]
+}
+
+# -----------------------------------------------------------------------------
 # Adminer Role
 # -----------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Deploy offhours-guard operator (chart 1.1.7, image 1.1.7) via ArgoCD, exposed at `offhours-guard.arffornia.com` behind Keycloak auth
- Schedule arcane, nexus servers and velocity proxy to sleep at **03:00** and wake at **07:00** Europe/Paris, with manual override available from the dashboard
- Add Vault policy/role for envoy-auth secret and Cloudflare DNS record (proxied)

## Test plan

- [ ] `terraform plan` shows only the expected DNS record, policy and role additions
- [ ] ArgoCD syncs `offhours-guard` app cleanly (Helm chart + CRD installed)
- [ ] `offhours-guard.arffornia.com` is reachable and protected by Keycloak
- [ ] Dashboard shows arcane, nexus and proxy schedules
- [ ] Manual sleep/wake buttons work for each server from the dashboard
- [ ] Servers automatically sleep at 03:00 and wake at 07:00
- [ ] Verify deployment names match (`kubectl get deploy -A | grep arffornia`) — update `targetRefs` in OffhoursSchedules if needed